### PR TITLE
WIP, Fix genPutArgStkFieldList for constant long arg

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -11163,7 +11163,11 @@ unsigned CodeGen::getFirstArgWithStackSlot()
 //
 void CodeGen::genSinglePush()
 {
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+    assert(false);
+#else
     genStackLevel += sizeof(void*);
+#endif
 }
 
 //------------------------------------------------------------------------
@@ -11171,7 +11175,11 @@ void CodeGen::genSinglePush()
 //
 void CodeGen::genSinglePop()
 {
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+    assert(false);
+#else
     genStackLevel -= sizeof(void*);
+#endif
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -3927,12 +3927,17 @@ void CodeGen::genGCWriteBarrier(GenTreePtr tgt, GCInfo::WriteBarrierForm wbf)
         }
 #endif // DEBUG
 #endif // 0
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+        printf("NYI\n");
+        assert(false);
+#else
         genStackLevel += 4;
         inst_IV(INS_push, wbKind);
         genEmitHelperCall(helper,
                           4,           // argSize
                           EA_PTRSIZE); // retSize
         genStackLevel -= 4;
+#endif // UNIX_X86_ABI && FEATURE_FIXED_OUT_ARGS
     }
     else
     {
@@ -7500,6 +7505,10 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
     unsigned saveStackLvl2 = genStackLevel;
 
 #if defined(_TARGET_X86_)
+#if FEATURE_FIXED_OUT_ARGS
+    // TODO: Fix here or disable profiler
+    assert(false);
+#else
     // Important note: when you change enter probe layout, you must also update SKIP_ENTER_PROF_CALLBACK()
     // for x86 stack unwinding
 
@@ -7512,6 +7521,7 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
     {
         inst_IV(INS_push, (size_t)compiler->compProfilerMethHnd);
     }
+#endif // !FEATURE_FIXED_OUT_ARGS
 #elif defined(_TARGET_ARM_)
     // On Arm arguments are prespilled on stack, which frees r0-r3.
     // For generating Enter callout we would need two registers and one of them has to be r0 to pass profiler handle.
@@ -7687,6 +7697,10 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper /*= CORINFO_HELP_PROF_FC
 
 #elif defined(_TARGET_X86_)
 
+#if FEATURE_FIXED_OUT_ARGS
+    // TODO: Fix here or disable profiler
+    assert(false);
+#else
     //
     // Push the profilerHandle
     //
@@ -7712,6 +7726,7 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper /*= CORINFO_HELP_PROF_FC
     {
         compiler->fgPtrArgCntMax = 1;
     }
+#endif // FEATURE_FIXED_OUT_ARGS
 
 #elif defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -491,6 +491,9 @@ void CodeGen::genCodeForBBlist()
         }
 
         genStackLevel -= savedStkLvl;
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+        assert(genStackLevel == 0);
+#endif
 
 #ifdef DEBUG
         // compCurLife should be equal to the liveOut set, except that we don't keep

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -176,8 +176,10 @@ void genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode);
 
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
 #ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
 bool genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk);
 void genPushReg(var_types type, regNumber srcReg);
+#endif // !FEATURE_FIXED_OUT_ARGS
 void genPutArgStkFieldList(GenTreePutArgStk* putArgStk);
 #endif // _TARGET_X86_
 
@@ -253,7 +255,9 @@ bool genIsRegCandidateLocal(GenTreePtr tree)
 
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
 #ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
 bool m_pushStkArg;
+#endif // !FEATURE_FIXED_OUT_ARGS
 #else  // !_TARGET_X86_
 unsigned m_stkArgVarNum;
 unsigned m_stkArgOffset;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1365,6 +1365,7 @@ public:
     {
         return padStkAlign;
     }
+    unsigned GetCalleePop();
 #endif
     bool HasRegArgs()
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1334,8 +1334,12 @@ public:
     void ArgsComplete();
 
 #if defined(UNIX_X86_ABI)
-    void ArgsAlignPadding();
-#endif
+#if FEATURE_FIXED_OUT_ARGS
+    void ArgsReverseSlots();
+#else
+    void       ArgsAlignPadding();
+#endif // FEATURE_FIXED_OUT_ARGS
+#endif // UNIX_X86_ABI
 
     void SortArgs();
 

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1890,7 +1890,9 @@ private:
 #endif
 
 #ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
     void emitMarkStackLvl(unsigned stackLevel);
+#endif // !FEATURE_FIXED_OUT_ARGS
 #endif
 
     int emitNextRandomNop();

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -725,6 +725,7 @@ unsigned emitter::emitGetPrefixSize(code_t code)
 }
 
 #ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
 /*****************************************************************************
  *
  *  Record a non-empty stack
@@ -744,6 +745,7 @@ void emitter::emitMarkStackLvl(unsigned stackLevel)
     if (emitMaxStackDepth < emitCurStackLvl)
         emitMaxStackDepth = emitCurStackLvl;
 }
+#endif // !FEATURE_FIXED_OUT_ARGS
 #endif
 
 /*****************************************************************************
@@ -5239,9 +5241,11 @@ void emitter::emitIns_Call(EmitCallType          callType,
            (ireg == REG_NA && xreg == REG_NA && xmul == 0 && disp < (int)emitComp->lvaCount));
     assert(callType != EC_INDIR_C || (ireg == REG_NA && xreg == REG_NA && xmul == 0 && disp != 0));
 
+#if !FEATURE_FIXED_OUT_ARGS
     // Our stack level should be always greater than the bytes of arguments we push. Just
     // a sanity test.
     assert((unsigned)abs((signed)argSize) <= codeGen->genStackLevel);
+#endif // !FEATURE_FIXED_OUT_ARGS
 
 #if STACK_PROBES
     if (emitComp->opts.compNeedStackProbes)
@@ -10657,6 +10661,9 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
                 assert(callInstrSize != 0);
 
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+// TODO: Fix here
+#else
                 if (args >= 0)
                 {
                     emitStackPop(dst, /*isCall*/ true, callInstrSize, args);
@@ -10665,6 +10672,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
                 {
                     emitStackKillArgs(dst, -args, callInstrSize);
                 }
+#endif // UNIX_X86_ABI && FEATURE_FIXED_OUT_ARGS
             }
 
             // Do we need to record a call location for GC purposes?

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1753,6 +1753,28 @@ void fgArgInfo::ArgsReverseSlots()
         }
     }
 }
+
+// Return number of slots to adjust ESP for callee pop
+unsigned fgArgInfo::GetCalleePop()
+{
+    unsigned curInx;
+    unsigned numSlots = 0;
+
+    for (curInx = 0; curInx < argCount; curInx++)
+    {
+        fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+        if (curArgTabEntry->numSlots > 0)
+        {
+            // The argument may be REG_STK or constant or register that goes to stack
+            assert(nextSlotNum >= curArgTabEntry->slotNum);
+
+            numSlots += curArgTabEntry->numSlots;
+        }
+    }
+
+    return numSlots;
+}
+
 #else  // FEATURE_FIXED_OUT_ARGS
 //  Get the stack alignment value for a Call holding this object
 //

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1709,6 +1709,51 @@ void fgArgInfo::ArgsComplete()
 }
 
 #if defined(UNIX_X86_ABI)
+#if FEATURE_FIXED_OUT_ARGS
+// Reverse slot number for each arguments so that arguments will be placed
+// in the same order when changed from push to move instruction.
+//
+// Notice: It would be better do reverser the order in lowering
+// so that we won't need ArgsReverseSlots()
+void fgArgInfo::ArgsReverseSlots()
+{
+    // To get the padding amount, sum up all the slots and get the remainder for padding
+    unsigned curInx;
+    unsigned numSlots     = 0;
+    unsigned numStackArgs = 0;
+
+    for (curInx = 0; curInx < argCount; curInx++)
+    {
+        fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+        if (curArgTabEntry->numSlots > 0)
+        {
+            // The argument may be REG_STK or constant or register that goes to stack
+            assert(nextSlotNum >= curArgTabEntry->slotNum);
+
+            numSlots += curArgTabEntry->numSlots;
+            numStackArgs++;
+        }
+    }
+
+    if (numStackArgs > 1)
+    {
+        for (curInx = 0; curInx < argCount; curInx++)
+        {
+            fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+            if (curArgTabEntry->numSlots > 0)
+            {
+                curArgTabEntry->slotNum = (nextSlotNum - 1) - curArgTabEntry->slotNum;
+                // Consider 2 or more slots used for the argument
+                // For example, if there is 4 arguments with numSlots value 1, 2, 1, 1 each
+                // nextSlotNum will be 5 and slot number will be like this
+                //     before: [O] [1][ ] [3] [4]
+                //      after: [4] [3] [2][ ] [0]
+                curArgTabEntry->slotNum -= (curArgTabEntry->numSlots - 1);
+            }
+        }
+    }
+}
+#else  // FEATURE_FIXED_OUT_ARGS
 //  Get the stack alignment value for a Call holding this object
 //
 //  NOTE: This function will calculate number of padding slots, to align the
@@ -1752,6 +1797,7 @@ void fgArgInfo::ArgsAlignPadding()
         this->padStkAlign = firstArgTabEntry->padStkAlign;
     }
 }
+#endif // FEATURE_FIXED_OUT_ARGS
 #endif // UNIX_X86_ABI
 
 void fgArgInfo::SortArgs()
@@ -4296,7 +4342,11 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
         call->fgArgInfo->ArgsComplete();
 
 #if defined(UNIX_X86_ABI)
+#if FEATURE_FIXED_OUT_ARGS
+        call->fgArgInfo->ArgsReverseSlots();
+#else
         call->fgArgInfo->ArgsAlignPadding();
+#endif // FEATURE_FIXED_OUT_ARGS
 #endif // UNIX_X86_ABI
 
 #ifdef LEGACY_BACKEND

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -373,6 +373,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
 
   #define FEATURE_WRITE_BARRIER    1       // Generate the proper WriteBarrier calls for GC
   #define FEATURE_FIXED_OUT_ARGS   0       // X86 uses push instructions to pass args
+//#define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
   #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers
   #define FEATURE_MULTIREG_STRUCT_PROMOTE  0  // True when we want to promote fields of a multireg struct into registers
   #define FEATURE_FASTTAILCALL     0       // Tail calls made as epilog+jmp

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -372,8 +372,8 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
 #endif // FEATURE_SIMD
 
   #define FEATURE_WRITE_BARRIER    1       // Generate the proper WriteBarrier calls for GC
-  #define FEATURE_FIXED_OUT_ARGS   0       // X86 uses push instructions to pass args
-//#define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
+//  #define FEATURE_FIXED_OUT_ARGS   0       // X86 uses push instructions to pass args
+  #define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
   #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers
   #define FEATURE_MULTIREG_STRUCT_PROMOTE  0  // True when we want to promote fields of a multireg struct into registers
   #define FEATURE_FASTTAILCALL     0       // Tail calls made as epilog+jmp


### PR DESCRIPTION
If Call's arg is a constant long arg, it faces Assertion failed 'srcReg
!= REG_NA'. To resolve it, instead of genSetRegToConst, 'mov'
instructions are inserted.