### PR TITLE
WIP, [x86/Linux] Enable call hoist for FOA

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -9260,6 +9260,10 @@ public:
     void fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgument);
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+    void fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgument);
+#endif
+
     void fgMorphMultiregStructArgs(GenTreeCall* call);
     GenTreePtr fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr fgEntryPtr);
 

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -359,8 +359,8 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
 
   #define FEATURE_WRITE_BARRIER    1       // Generate the proper WriteBarrier calls for GC
 #if defined(UNIX_X86_ABI)
-//#define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
-  #define FEATURE_FIXED_OUT_ARGS   0       // X86 uses push instructions to pass args
+  #define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
+//#define FEATURE_FIXED_OUT_ARGS   0       // X86 uses push instructions to pass args
 #else
   #define FEATURE_FIXED_OUT_ARGS   0       // X86 uses push instructions to pass args
 #endif


### PR DESCRIPTION
- change processing struct as call args in morph phase
- structs are handled from GT_LCL_VAR to GT_OBJ for call args
- TODO: cleanup & refactor